### PR TITLE
Set global brightness even if animate brightness is false

### DIFF
--- a/custom_components/animated_scenes/animations.py
+++ b/custom_components/animated_scenes/animations.py
@@ -436,6 +436,8 @@ class Animation:
             attributes["brightness"] = self.get_static_or_random(color[CONF_BRIGHTNESS])
         elif self._animate_brightness and self._global_brightness is not None:
             attributes["brightness"] = self.get_static_or_random(self._global_brightness)
+        elif isinstance(self._global_brightness, int):
+            attributes["brightness"] = self._global_brightness
 
         if CONF_BRIGHTNESS in color and color[CONF_COLOR_ONE_CHANGE_PER_TICK]:
             self._light_status[light] = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Brightness during animations now respects explicit integer global brightness values, removing unintended randomization and ensuring predictable output.
  - Users setting a fixed brightness (as an integer) will see consistent, deterministic brightness levels throughout animated scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->