### PR TITLE
Set global brightness even if animate brightness is false

### DIFF
--- a/custom_components/animated_scenes/animations.py
+++ b/custom_components/animated_scenes/animations.py
@@ -436,6 +436,10 @@ class Animation:
             attributes["brightness"] = self.get_static_or_random(color[CONF_BRIGHTNESS])
         elif self._animate_brightness and self._global_brightness is not None:
             attributes["brightness"] = self.get_static_or_random(self._global_brightness)
+        elif isinstance(self._global_brightness, int):
+            attributes["brightness"] = self._global_brightness
+        elif isinstance(self._global_brightness, list):
+            _LOGGER.warning("Global brightness is a list but animate_brightness is False, ignoring")
 
         if CONF_BRIGHTNESS in color and color[CONF_COLOR_ONE_CHANGE_PER_TICK]:
             self._light_status[light] = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures static brightness is correctly applied when brightness animation is off, providing consistent light levels in animated scenes.
  * Prevents unexpected dimming or brightening caused by previously ignored global brightness values.
  * Adds a clear log warning when an unsupported list is provided for global brightness while animation is disabled, aiding troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->