### PR TITLE
Fix ignore_off logic

### DIFF
--- a/custom_components/animated_scenes/animations.py
+++ b/custom_components/animated_scenes/animations.py
@@ -344,11 +344,7 @@ class Animation:
         if state is None:
             _LOGGER.warning("Entity %s not found, skipping", entity_id)
             return
-        if (
-            state.state != "off"
-            and entity_id not in self._active_lights
-            or (state.state == "off" and self._ignore_off and entity_id not in self._active_lights)
-        ):
+        if entity_id not in self._active_lights and (state.state != "off" or not self._ignore_off):
             self._active_lights.append(entity_id)
 
     def add_lights(self, ids: list) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of lights that are currently off when starting animated scenes. Lights are now added based on the ignore_off setting in a more consistent, predictable way, reducing unexpected activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->